### PR TITLE
feat(hashicorp-vault-signing-manager): add method to expose vault key info

### DIFF
--- a/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault-signing-manager.spec.ts
+++ b/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault-signing-manager.spec.ts
@@ -84,6 +84,13 @@ describe('HashicorpVaultSigningManager Class', () => {
       expect(signer instanceof VaultSigner).toBe(true);
     });
   });
+
+  describe('method: getVaultKeys', () => {
+    it('should return the vault keys', async () => {
+      const result = await signingManager.getVaultKeys();
+      expect(result).toEqual(accounts);
+    });
+  });
 });
 
 describe('class VaultSigner', () => {

--- a/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault-signing-manager.spec.ts
+++ b/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault-signing-manager.spec.ts
@@ -66,13 +66,13 @@ describe('HashicorpVaultSigningManager Class', () => {
       expect(result).toEqual(accounts.map(({ address }) => address));
     });
 
-    it("should throw an error if the Signing Manager doesn't have a SS58 format", async () => {
+    it("should throw an error if the Signing Manager doesn't have a SS58 format", () => {
       signingManager = new HashicorpVaultSigningManager({
         url,
         token,
       });
 
-      expect(signingManager.getAccounts()).rejects.toThrow(
+      return expect(signingManager.getAccounts()).rejects.toThrow(
         "Cannot call 'getAccounts' before calling 'setSs58Format'. Did you forget to use this Signing Manager to connect with the Polymesh SDK?"
       );
     });
@@ -89,6 +89,16 @@ describe('HashicorpVaultSigningManager Class', () => {
     it('should return the vault keys', async () => {
       const result = await signingManager.getVaultKeys();
       expect(result).toEqual(accounts);
+    });
+
+    it("should throw an error if the Signing Manager doesn't have a SS58 format", () => {
+      signingManager = new HashicorpVaultSigningManager({
+        url,
+        token,
+      });
+      return expect(signingManager.getVaultKeys()).rejects.toThrowError(
+        "Cannot call 'getVaultKeys' before calling 'setSs58Format'. Did you forget to use this Signing Manager to connect with the Polymesh SDK?"
+      );
     });
   });
 });

--- a/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault-signing-manager.ts
+++ b/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault-signing-manager.ts
@@ -121,7 +121,6 @@ export class HashicorpVaultSigningManager implements SigningManager {
    */
   public async getAccounts(): Promise<string[]> {
     const ss58Format = this.getSs58Format('getAccounts');
-    this.getSs58Format('getAccounts');
 
     const keys = await this.vault.fetchAllKeys();
 
@@ -137,6 +136,8 @@ export class HashicorpVaultSigningManager implements SigningManager {
 
   /**
    * Return the information about each key available to sign extrinsics with in the Hashicorp Vault.
+   *
+   * @throws if called before calling `setSs58Format`. Normally, `setSs58Format` will be called by the SDK when instantiated
    */
   public async getVaultKeys(): Promise<AddressedVaultKey[]> {
     const ss58Format = this.getSs58Format('getVaultKeys');

--- a/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault-signing-manager.ts
+++ b/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault-signing-manager.ts
@@ -4,6 +4,7 @@ import { hexToU8a, u8aToHex } from '@polkadot/util';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 import { PolkadotSigner, SigningManager } from '@polymathnetwork/signing-manager-types';
 
+import { AddressedVaultKey } from '../types';
 import { HashicorpVault, VaultKey } from './hashicorp-vault';
 
 export class VaultSigner implements PolkadotSigner {
@@ -120,6 +121,7 @@ export class HashicorpVaultSigningManager implements SigningManager {
    */
   public async getAccounts(): Promise<string[]> {
     const ss58Format = this.getSs58Format('getAccounts');
+    this.getSs58Format('getAccounts');
 
     const keys = await this.vault.fetchAllKeys();
 
@@ -131,6 +133,18 @@ export class HashicorpVaultSigningManager implements SigningManager {
    */
   public getExternalSigner(): PolkadotSigner {
     return this.externalSigner;
+  }
+
+  /**
+   * Return the information about each key available to sign extrinsics with in the Hashicorp Vault.
+   */
+  public async getVaultKeys(): Promise<AddressedVaultKey[]> {
+    const ss58Format = this.getSs58Format('getVaultKeys');
+    const keys = await this.vault.fetchAllKeys();
+    return keys.map(key => ({
+      ...key,
+      address: encodeAddress(key.publicKey, ss58Format),
+    }));
   }
 
   /**

--- a/packages/hashicorp-vault-signing-manager/src/types/index.ts
+++ b/packages/hashicorp-vault-signing-manager/src/types/index.ts
@@ -1,0 +1,8 @@
+import { VaultKey } from '../lib/hashicorp-vault/types';
+
+export interface AddressedVaultKey extends VaultKey {
+  /**
+   * ss58 encoded version of the publicKey
+   */
+  address: string;
+}


### PR DESCRIPTION
Adds getVaultKeys to HashicorpVaultSigningManager so a user is able to fetch Vault information of
the available signing keys